### PR TITLE
[FE] Feat: StoryList 부모 페이지 진입 로직 리팩토링

### DIFF
--- a/Frontend/src/pages/StoryList.jsx
+++ b/Frontend/src/pages/StoryList.jsx
@@ -16,11 +16,14 @@ const categories = [
 const StoryList = () => {
   const navigate = useNavigate();
   const [activeCategory, setActiveCategory] = useState(categories[0].code);
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const [stories, setStories] = useState([]);
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState(null);
 
+  const handleGoToParentsPage = () => {
+    navigate('/parents'); 
+  }
+  
   useEffect(() => {
     const loadStories = async () => {
       setIsLoading(true); 
@@ -50,7 +53,7 @@ const StoryList = () => {
   return (
     <div style={styles.container}>
       <header style={styles.header}>
-        <button style={styles.parentButton} onClick={() => setIsModalOpen(true)}>
+        <button style={styles.parentButton} onClick={handleGoToParentsPage}>
           부모 페이지
         </button>
       </header>


### PR DESCRIPTION
## 관련 이슈
>close #136

<br>

## 작업 내용
> 
- 사용하지 않는 모달 관련 상태(`isModalOpen`) 및 로직 제거
- '부모 페이지' 버튼 클릭 시 `useNavigate`를 사용하여 `/parents` 경로로 이동하도록 핸들러(`handleGoToParentsPage`) 구현

<br>

## 기타 (선택)
> 
