### PR TITLE
[FE] fix: 모바일 AI 대화 마이크 버튼 이미지 시스템 메뉴 차단

### DIFF
--- a/Frontend/src/pages/AIChat.jsx
+++ b/Frontend/src/pages/AIChat.jsx
@@ -330,10 +330,14 @@ const AIChat = () => {
                             startRecording(); 
                         }}
                         onTouchEnd={stopRecording}  
-                        onContextMenu={(e) => e.preventDefault()}
+                        onContextMenu={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            return false;
+                        }}
                         disabled={isMicDisabled}
                     >
-                        <img src={micIcon} alt ="마이크" style={styles.micIcon} />
+                        <img src={micIcon} alt ="마이크" style={styles.micIcon} draggable="false" />
                     </button>
                     
                     <p style={styles.dialogueGuidanceText}>
@@ -557,11 +561,18 @@ const styles = {
         justifyContent: 'center', 
         alignItems: 'center', 
         cursor: 'pointer', 
-        boxShadow: '0 4px 20px rgba(255, 160, 122, 0.5)',
+        boxShadow: '0 4px 20px rgba(255, 160, 122, 0.5)',
+        touchAction: 'none',         
+        userSelect: 'none',          
+        WebkitUserSelect: 'none',    
+        WebkitTouchCallout: 'none',
     },
     micIcon: { 
         width: '80%',    
-        height: '80%'
+        height: '80%',
+        pointerEvents: 'none',
+        userSelect: 'none',
+        WebkitUserSelect: 'none'
     },
     dialogueGuidanceText: {
         marginTop: '10px', 


### PR DESCRIPTION
## 관련 이슈
> Close #142

<br>

## 작업 내용
> 
- `AIChat.jsx` 
  - `micIcon` (이미지): `pointer-events: none`을 추가하여 터치 이벤트를 버튼으로 투과
  - `micButton` (버튼): `touch-action: none` (안드로이드 제스처 차단) 및 `-webkit-touch-callout: none` (iOS 길게 누르기 메뉴 차단) 추가
  - 이미지 태그에 `draggable="false"` 속성 추가
  - 버튼의 `onContextMenu` 핸들러에 `e.stopPropagation()`을 추가하여 이벤트 전파 방지

<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
