### PR TITLE
[FE] fix: 모바일 마이크 버튼 이미지 저장 메뉴 및 드래그 현상 해결

### DIFF
--- a/Frontend/src/pages/AIChat.jsx
+++ b/Frontend/src/pages/AIChat.jsx
@@ -326,10 +326,19 @@ const AIChat = () => {
                         onMouseDown={startRecording}
                         onMouseUp={stopRecording}    
                         onTouchStart={(e) => {
-                            e.preventDefault(); // 기본 컨텍스트 메뉴 활성화 차단
-                            startRecording(); 
-                        }}
-                        onTouchEnd={stopRecording}  
+                            e.preventDefault();
+                            e.stopPropagation();  
+                            startRecording(); 
+                        }}
+                        onTouchEnd={(e) => {  
+                            e.preventDefault();  
+                            e.stopPropagation();  
+                            stopRecording();
+                        }}
+                        onTouchMove={(e) => {  
+                            e.preventDefault();
+                            e.stopPropagation();
+                        }}
                         onContextMenu={(e) => {
                             e.preventDefault();
                             e.stopPropagation();
@@ -337,7 +346,17 @@ const AIChat = () => {
                         }}
                         disabled={isMicDisabled}
                     >
-                        <img src={micIcon} alt ="마이크" style={styles.micIcon} draggable="false" />
+                        <img 
+                            src={micIcon} 
+                            alt="마이크" 
+                            style={styles.micIcon}
+                            draggable="false"
+                            onDragStart={(e) => e.preventDefault()}  
+                            onContextMenu={(e) => e.preventDefault()}  
+                            onTouchStart={(e) => e.preventDefault()}  
+                            onTouchEnd={(e) => e.preventDefault()}  
+                            onTouchMove={(e) => e.preventDefault()}  
+                        />
                     </button>
                     
                     <p style={styles.dialogueGuidanceText}>
@@ -566,13 +585,17 @@ const styles = {
         userSelect: 'none',          
         WebkitUserSelect: 'none',    
         WebkitTouchCallout: 'none',
+        WebkitUserDrag: 'none'
     },
     micIcon: { 
         width: '80%',    
         height: '80%',
         pointerEvents: 'none',
         userSelect: 'none',
-        WebkitUserSelect: 'none'
+        WebkitUserSelect: 'none',
+        WebkitTouchCallout: 'none',  
+        WebkitUserDrag: 'none',  
+        objectFit: 'contain'  
     },
     dialogueGuidanceText: {
         marginTop: '10px', 


### PR DESCRIPTION
## 관련 이슈
> Close #144

<br>

## 작업 내용
> 
- `AIChat.jsx`
  - `micButton`, `micIcon` 스타일에 `WebkitUserDrag: 'none'`을 추가하여 Safari 브라우저 드래그 방지
  - `micIcon`에 `objectFit: 'contain'` 추가
  - `onTouchStart`, `onTouchEnd` 핸들러에 `e.stopPropagation()` 추가
  - `onTouchMove` 핸들러를 추가하여 드래그 제스처 차단
  - `draggable="false"` 속성 명시
  - `onDragStart`, `onContextMenu`, `onTouchStart`, `onTouchEnd`, `onTouchMove` 모든 이벤트에 대해 `e.preventDefault()`를 호출하여 브라우저의 기본 동작을 차단

<br>

## 기타 (선택)
> 