### PR TITLE
[FE] Feat: GA4 이벤트 연동 및 커스텀 파라미터 구현

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -6,14 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light">
     <title>나무럭무럭</title>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-L9G2TS3RHX"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-L9G2TS3RHX');
-    </script>
     <script src="https://t.contentsquare.net/uxa/4f56b668592ef.js"></script>
   </head>
   <body>

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.13.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-ga4": "^2.1.0",
         "react-router-dom": "^7.9.4"
       },
       "devDependencies": {
@@ -2881,6 +2882,12 @@
       "peerDependencies": {
         "react": "^19.2.0"
       }
+    },
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --port 5173",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"
@@ -14,6 +14,7 @@
     "axios": "^1.13.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-ga4": "^2.1.0",
     "react-router-dom": "^7.9.4"
   },
   "devDependencies": {

--- a/Frontend/src/layouts/DefaultLayout.jsx
+++ b/Frontend/src/layouts/DefaultLayout.jsx
@@ -1,21 +1,31 @@
 // src/layouts/DefaultLayout.jsx
-import React, { useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
-import { supabase } from '../supabaseClient'; // 2. supabase 클라이언트 추가 (경로 확인!)
+
+import { useEffect } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
+import { supabase } from '../supabaseClient'; 
+import ReactGA from 'react-ga4';
+
 const DefaultLayout = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    ReactGA.send({ hitType: "pageview", page: location.pathname });
+    console.log(`[Analytics] 페이지 이동: ${location.pathname}`);
+  }, [location]); 
 
   useEffect(() => {
     const { data: authListener } = supabase.auth.onAuthStateChange(
       (event, session) => {
-        // (디버깅용)
         console.log(`Supabase auth event: ${event}`);
 
         if (event === 'SIGNED_IN') {
           console.log('로그인 됨:', session?.user?.email);
+          ReactGA.set({ userId: session.user.id });
         }
 
         if (event === 'SIGNED_OUT') {
           console.log('로그아웃 됨');
+          ReactGA.set({ userId: null });
         }
       }
     );

--- a/Frontend/src/main.jsx
+++ b/Frontend/src/main.jsx
@@ -5,6 +5,9 @@ import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 import router from './routes/Router'; 
 import './index.css';
+import ReactGA from "react-ga4";
+
+ReactGA.initialize("G-L9G2TS3RHX");
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/Frontend/src/pages/Login.jsx
+++ b/Frontend/src/pages/Login.jsx
@@ -1,14 +1,42 @@
 // src/pages/Login.jsx
 
+import { useEffect, useRef } from 'react';
 import { supabase } from '../supabaseClient';
+import ReactGA from 'react-ga4';
+
 const Login = () => {
+
+  const isLoginProcessStarted = useRef(false);
+
+  useEffect(() => {
+    ReactGA.event({
+      category: "Authentication",
+      action: "login_screen_view",
+      label: "로그인 화면 진입"
+    });
+
+    console.log("[Analytics] login_screen_view 전송됨");
+
+    return () => {
+      if (!isLoginProcessStarted.current) {
+        ReactGA.event({
+          category: "Authentication",
+          action: "login_exit",
+          label: "로그인 하지 않고 이탈"
+        });
+        console.log("[Analytics] login_exit 전송됨 (이탈)");
+      }
+    };
+  }, []);
+  
   const handleSignIn = async () => {
     console.log('구글 로그인 버튼 클릭됨. Supabase 인증을 시작합니다.');
-
+    
+    isLoginProcessStarted.current = true;
+    
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        // 기본 도메인으로 리디렉션 수정(자동 리디렉션 처리를 위해)
         redirectTo: window.location.origin
       }
     });

--- a/Frontend/src/pages/StoryList.jsx
+++ b/Frontend/src/pages/StoryList.jsx
@@ -1,8 +1,9 @@
 // src/pages/StoryList.jsx
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { fetchStoriesByCategory } from '../api/storyApi.js';
+import ReactGA from 'react-ga4';
 
 const categories = [
   { code: 'SA', name: '내 마음 살펴보기' },
@@ -12,6 +13,14 @@ const categories = [
   { code: 'RDM', name: '생각하고 바르게 선택하기' }
 ];
 
+//GA를 위한 파라미터 변환용 맵
+const CASEL_MAP = {
+  'SA': 'self_awareness',
+  'SM': 'self_management',
+  'SOA': 'social_awareness',
+  'RS': 'relationship_skills',
+  'RDM': 'responsible_decision_making'
+};
 
 const StoryList = () => {
   const navigate = useNavigate();
@@ -24,6 +33,15 @@ const StoryList = () => {
     navigate('/parents'); 
   }
   
+  useEffect(() => {
+    ReactGA.event({
+      category: "Story",
+      action: "book_list_view",
+      label: "동화 목록 화면 진입"
+    });
+    console.log("[Analytics] book_list_view");
+  }, []);
+
   useEffect(() => {
     const loadStories = async () => {
       setIsLoading(true); 
@@ -46,7 +64,28 @@ const StoryList = () => {
   }, [activeCategory]); 
 
   
+  const handleCategoryClick = (categoryCode) => {
+    setActiveCategory(categoryCode); // 탭 변경
+
+    const caselDomainName = CASEL_MAP[categoryCode] || categoryCode;
+    ReactGA.event({
+      category: "Story",
+      action: "casel_tab_click",
+      label: "CASEL 탭 클릭",
+      casel_domain: caselDomainName 
+    });
+    console.log(`[Analytics] casel_tab_click (param: ${caselDomainName})`);
+  };
+
   const handleStorySelect = (storyId) => {
+    ReactGA.event({
+      category: "Story",
+      action: "book_select",
+      label: "동화 상세 이동",
+      story_id: storyId 
+    });
+    console.log(`[Analytics] book_select (param: ${storyId})`);
+
     navigate(`/story/${storyId}`);
   };
 
@@ -63,7 +102,7 @@ const StoryList = () => {
           {categories.map((cat) => (
             <button
               key={cat.code} 
-              onClick={() => setActiveCategory(cat.code)}
+              onClick={() => handleCategoryClick(cat.code)}
               style={{
                 ...styles.categoryButton,
                 ...(activeCategory === cat.code ? styles.activeCategory : {})
@@ -80,7 +119,7 @@ const StoryList = () => {
           {!isLoading && !error && stories.map((story) => (
             <div
               key={story.id} 
-              onClick={() => handleStorySelect(story.id)} 
+              onClick={() => handleStorySelect(story.id)}
               style={styles.storyCard}
             >
               <div style={styles.storyImageContainer}>


### PR DESCRIPTION
## 관련 이슈
> Close #152

<br>

## 작업 내용
>
- 패키지 및 초기화: `react-ga4` 설치, `main.jsx` 초기화, `DefaultLayout` 페이지 뷰 추적
- 로그인: 진입(`login_screen_view`) 및 이탈(`login_exit`) 추적 로직 구현
- 프로필 생성: 화면 체류 시간(`duration`) 측정 및 단계별 진입 이벤트 구현
- 동화 목록: 탭 클릭 시 `casel_domain` 파라미터 전송, 동화 선택 이벤트 구현
- 동화 읽기:* 읽기 시작/완료 및 페이지 넘김 시 `page_number` 추적
- AI 대화: 대화 단계(`step_number`) 및 답변 소요 시간(`answer_duration`) 측정 로직 구현

<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
