### PR TITLE
[BE] Fix : 인트로 질문도 대화 로그에 저장 되도록 수정

### DIFF
--- a/Backend/src/main/java/com/example/namurokmurok/domain/conversation/enums/Stage.java
+++ b/Backend/src/main/java/com/example/namurokmurok/domain/conversation/enums/Stage.java
@@ -1,5 +1,5 @@
 package com.example.namurokmurok.domain.conversation.enums;
 
 public enum Stage {
-    S1, S2, S3, S4, S5;
+    INTRO, S1, S2, S3, S4, S5;
 }

--- a/Backend/src/main/java/com/example/namurokmurok/domain/conversation/service/ConversationService.java
+++ b/Backend/src/main/java/com/example/namurokmurok/domain/conversation/service/ConversationService.java
@@ -4,6 +4,8 @@ import com.example.namurokmurok.domain.conversation.dto.*;
 import com.example.namurokmurok.domain.conversation.entity.Conversation;
 import com.example.namurokmurok.domain.conversation.entity.Dialogue;
 import com.example.namurokmurok.domain.conversation.enums.ConversationStatus;
+import com.example.namurokmurok.domain.conversation.enums.Speaker;
+import com.example.namurokmurok.domain.conversation.enums.Stage;
 import com.example.namurokmurok.domain.conversation.repository.ConversationRepository;
 import com.example.namurokmurok.domain.conversation.repository.DialogueRepository;
 import com.example.namurokmurok.domain.story.entity.Story;
@@ -99,6 +101,23 @@ public class ConversationService {
                 .build();
 
         conversationRepository.save(conversation);
+
+        // 인트로 질문 Dialogue에 저장
+        Dialogue introLog = Dialogue.builder()
+                .conversation(conversation)
+                .turnNumber(1)
+                .stage(Stage.INTRO)
+                .retryCount(0)
+                .speaker(Speaker.AI)
+                .content(response.getAi_intro())
+                .audioUrl(introAudioUrl)
+                .createdAt(LocalDateTime.now())
+                .isSafe(true)
+                .unsafeReason(null)
+                .fallbackTriggered(false)
+                .build();
+
+        dialogueRepository.save(introLog);
 
         return response;
     }


### PR DESCRIPTION
## 관련 이슈
#164 
<br>

## 작업 내용
- 인트로 질문도 대화 로그에 저장 되도록 수정 (turn_number = 1)
<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
