### PR TITLE
[FE] feat: 대화 중도 이탈(Failed) 처리 로직 및 대화 목록 UI 수정

### DIFF
--- a/Frontend/src/api/chatApi.js
+++ b/Frontend/src/api/chatApi.js
@@ -64,6 +64,14 @@ export const postConversationTurn = async ({
     throw error;
   }
 };
+export const failConversation = async (conversationId) => {
+    try {
+        const response = await apiClient.patch(`/api/conversations/${conversationId}/fail`);
+        return response.data;
+    } catch (error) {
+        console.error("대화 중단 처리 실패:", error);
+    }
+};
 
 export const fetchActionCard = async (storyId) => {
   if (!storyId) {

--- a/Frontend/src/pages/ChatListPage.jsx
+++ b/Frontend/src/pages/ChatListPage.jsx
@@ -36,9 +36,9 @@ const ChatListPage = () => {
         navigate(-1); 
     };
 
-    const handleItemClick = (id) => {
-        navigate(`/parents/chat/${id}`);
-    };
+    const handleItemClick = (item) => {
+    navigate(`/parents/chat/${item.id}`, { state: { status: item.status } });
+};
 
     const formatDate = (dateString) => {
         // 2025-11-25 -> 25/11/25 형태로 변환
@@ -81,20 +81,32 @@ const ChatListPage = () => {
                         <div style={styles.loadingText}>목록을 불러오는 중...</div>
                     ) : (
                         chatList.length > 0 ? (
-                            chatList.map((item) => (
-                                <button 
-                                    key={item.id} 
-                                    style={styles.listItem}
-                                    onClick={() => handleItemClick(item.id)}
-                                >
-                                    <div style={styles.itemContent}>
-                                        {/* API 데이터의 date 형식이 YYYY-MM-DD라면 formatDate 함수 사용 고려 */}
-                                        <span style={styles.itemDate}>{formatDate(item.date) || item.date}</span>
-                                        <span style={styles.itemTitle}>{item.title}</span>
-                                    </div>
-                                    <img src={rightArrowIcon} alt="상세보기" style={styles.arrowIconImg} />
-                                </button>
-                            ))
+                            chatList.map((item) => {
+                                // ✅ 수정 포인트 1: 중괄호 {}를 열고 로그를 찍은 뒤 return을 씁니다.
+                                console.log(`ID: ${item.id}, Title: ${item.title}, Status:`, item.status);
+
+                                return (
+                                    <button 
+                                        key={item.id} 
+                                        style={styles.listItem}
+                                        onClick={() => handleItemClick(item)}
+                                    >
+                                        <div style={styles.itemContent}>
+                                            <span style={styles.itemDate}>{formatDate(item.date) || item.date}</span>
+                                            <span style={styles.itemTitle}>{item.title}</span>
+                                        </div>
+
+                                        {/* ✅ 수정 포인트 2: 오른쪽 정렬 영역과 중단 메시지 코드 복구 */}
+                                        <div style={styles.itemRight}>
+                                            {/* status가 FAILED(대소문자 무관)일 때만 표시 */}
+                                            {(item.status?.toUpperCase() === 'FAILED' || item.status === 'failed') && (
+                                                <span style={styles.failedText}>대화 중단됨</span>
+                                            )}
+                                            <img src={rightArrowIcon} alt="상세보기" style={styles.arrowIconImg} />
+                                        </div>
+                                    </button>
+                                );
+                            })
                         ) : (
                             <div style={styles.loadingText}>대화 목록이 없습니다.</div>
                         )
@@ -193,6 +205,17 @@ const styles = {
         color: 'var(--color-text-dark)',
         fontFamily: "var(--font-family-primary)",
         marginRight: '10px'
+    },
+    itemRight: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '12px',
+    },
+    failedText: {
+        fontSize: '13px',
+        color: '#999999',
+        fontFamily: "var(--font-family-primary)",
+        whiteSpace: 'nowrap'
     },
     arrowIconImg: {
         width: '24px',


### PR DESCRIPTION
## 관련 이슈
> close #177

<br>

## 작업 내용
> 
- `chatApi.js` :  대화 상태를 'FAILED'로 변경하는 `failConversation` 함수 추가
- `AIChat.jsx`
  - 대화 정상 종료 여부(`isCompleted`) 추적
  - 컴포넌트 언마운트(이탈) 시, 정상 종료가 아닐 경우 중단 API 호출 로직 구현
- `ChatListPage.jsx` : 대화 상태가 `FAILED`인 경우, 우측에 '대화 중단됨' 텍스트 표시

<br>

## 기타 (선택)
> 