### PR TITLE
[FE] feat: 대화 중도 이탈(Failed) UI 및 로직 구현

### DIFF
--- a/Frontend/src/pages/ChatDetailPage.jsx
+++ b/Frontend/src/pages/ChatDetailPage.jsx
@@ -9,6 +9,7 @@ const ChatDetailPage = () => {
     const { conversationId } = useParams();
     const navigate = useNavigate();
     const [chatLogs, setChatLogs] = useState([]);
+    const [chatStatus, setChatStatus] = useState(null);
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
@@ -24,6 +25,7 @@ const ChatDetailPage = () => {
 
                 if (response && response.success) {
                     setChatLogs(response.data.logs);
+                    setChatStatus(response.data.status);
                 } else {
                     console.error("데이터를 불러오지 못했습니다:", response?.message);
                 }
@@ -68,6 +70,7 @@ const ChatDetailPage = () => {
                             border-radius: 10px;
                             background-clip: padding-box;
                             border: 4px solid transparent;
+                        }
                     `}
                 </style>
 
@@ -75,46 +78,31 @@ const ChatDetailPage = () => {
                     {isLoading ? (
                         <div style={styles.loadingText}>대화를 불러오는 중...</div>
                     ) : (
-                        chatLogs.map((log) => {
-                            const isAi = log.speaker === 'AI';
-                            const isViolated = log.is_violated;
-                            return (
-                                <div key={log.log_id} style={styles.messageRow}>
-                                    {isAi && (
-                                        <div style={{...styles.avatar, backgroundColor: 'var(--color-third)'}}>
-                                            AI
+                        <>
+                            {chatLogs.map((log) => {
+                                const isAi = log.speaker === 'AI';
+                                const isViolated = log.is_violated;
+                                return (
+                                    <div key={log.log_id} style={styles.messageRow}>
+                                        {isAi && ( <div style={{...styles.avatar, backgroundColor: 'var(--color-third)'}}> AI </div> )}
+                                        <div style={{ ...styles.chatBubble, backgroundColor: isAi ? 'var(--color-third)' : 'var(--color-main)', border: isViolated ? '2px solid var(--color-fourth)' : '2px solid var(--color-text-dark)', marginLeft: isAi ? '10px' : '0', marginRight: isAi ? '0' : '10px' }}>
+                                                <p style={{ ...styles.chatText, color: isViolated ? 'var(--color-fourth)' : 'var(--color-text-dark)', }}>
+                                                    {isViolated && ( <img src={warningIcon} alt="warning" style={styles.warningIconImg} /> )}
+                                                    {log.content}
+                                                </p>
                                         </div>
-                                    )}
-
-                                    <div style={{
-                                        ...styles.chatBubble,
-                                        backgroundColor: isAi ? 'var(--color-third)' : 'var(--color-main)',
-                                        
-                                        border: isViolated 
-                                            ? '2px solid var(--color-fourth)' 
-                                            : '2px solid var(--color-text-dark)',
-
-                                        marginLeft: isAi ? '10px' : '0',
-                                        marginRight: isAi ? '0' : '10px'
-                                    }}>
-                                        <p style={{
-                                            ...styles.chatText,
-                                            color: isViolated ? 'var(--color-fourth)' : 'var(--color-text-dark)',
-                                        }}>
-                                            {isViolated && (
-                                                <img src={warningIcon} alt="warning" style={styles.warningIconImg} />
-                                            )}
-                                            {log.content}
-                                        </p>
+                                        {!isAi && ( <div style={{...styles.avatar, backgroundColor: 'var(--color-main)'}}> 아이 </div> )}
                                     </div>
-                                    {!isAi && (
-                                        <div style={{...styles.avatar, backgroundColor: 'var(--color-main)'}}>
-                                            아이
-                                        </div>
-                                    )}
+                                );
+                            })}
+                            
+                            {chatStatus === 'FAILED' && (
+                                <div style={styles.failedNotice}>
+                                    ---------- 학습 도중 이탈로 대화 내용은 진행된 부분까지만 저장됩니다. ----------
                                 </div>
-                            );
-                        })
+                            )}
+                            
+                        </>
                     )}
                 </div>
             </main>
@@ -233,6 +221,8 @@ const styles = {
         color: 'var(--color-text-dark)',
         lineHeight: '1.4',
         wordBreak: 'keep-all',
+        display: 'flex',
+        alignItems: 'center'
     },
     warningIconImg: {
         width: '18px',
@@ -245,6 +235,13 @@ const styles = {
         fontSize: '1.2rem',
         marginTop: '50px',
     },
+    failedNotice: {
+        textAlign: 'center',
+        color: 'var(--color-text-dark)',
+        marginTop: '20px',
+        marginBottom: '10px',
+        fontFamily: "var(--font-family-primary)"
+    }
 };
 
 export default ChatDetailPage;

--- a/Frontend/src/pages/ChatListPage.jsx
+++ b/Frontend/src/pages/ChatListPage.jsx
@@ -82,7 +82,6 @@ const ChatListPage = () => {
                     ) : (
                         chatList.length > 0 ? (
                             chatList.map((item) => {
-                                // ✅ 수정 포인트 1: 중괄호 {}를 열고 로그를 찍은 뒤 return을 씁니다.
                                 console.log(`ID: ${item.id}, Title: ${item.title}, Status:`, item.status);
 
                                 return (
@@ -96,11 +95,12 @@ const ChatListPage = () => {
                                             <span style={styles.itemTitle}>{item.title}</span>
                                         </div>
 
-                                        {/* ✅ 수정 포인트 2: 오른쪽 정렬 영역과 중단 메시지 코드 복구 */}
                                         <div style={styles.itemRight}>
                                             {/* status가 FAILED(대소문자 무관)일 때만 표시 */}
                                             {(item.status?.toUpperCase() === 'FAILED' || item.status === 'failed') && (
-                                                <span style={styles.failedText}>대화 중단됨</span>
+                                                <div style={styles.failedBadge}>
+                                                진행 중 이탈
+                                                </div>
                                             )}
                                             <img src={rightArrowIcon} alt="상세보기" style={styles.arrowIconImg} />
                                         </div>
@@ -211,11 +211,21 @@ const styles = {
         alignItems: 'center',
         gap: '12px',
     },
-    failedText: {
-        fontSize: '13px',
-        color: '#999999',
+    failedBadge: {
+        backgroundColor: 'var(--color-third)', 
+        border: '2px solid var(--color-text-dark)', 
+        borderRadius: '20px', 
+        padding: '2px 10px', 
+        fontSize: '12px', 
+        color: 'var(--color-text-dark)', 
         fontFamily: "var(--font-family-primary)",
-        whiteSpace: 'nowrap'
+        whiteSpace: 'nowrap', 
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '26px', 
+        boxSizing: 'border-box', 
+        boxShadow: '0 1px 2px rgba(0,0,0,0.1)', 
     },
     arrowIconImg: {
         width: '24px',


### PR DESCRIPTION
## 관련 이슈
> Close #185
<br>

## 작업 내용
> 
- `ChatDetailPage`: 대화 상세 조회 API 연동 시 `status` 값(`FAILED`) 확인 로직 추가
- `ChatListPage`: 대화 목록에서 중도 이탈된 건에 대한 UI 수정

<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
