### PR TITLE
[FE] Feat : 동화 이어 읽기 기능 및 팝업 구현

### DIFF
--- a/Frontend/src/api/storyApi.js
+++ b/Frontend/src/api/storyApi.js
@@ -53,3 +53,29 @@ export const fetchStoryScene = async (storyId) => {
     throw error; 
   }
 };
+export const fetchLastReadPage = async (storyId, childId) => {
+  const API_ENDPOINT = `/api/stories/${storyId}/children/${childId}/pages`;
+
+  try {
+    const response = await instance.get(API_ENDPOINT);
+    if (!response.data.success) {
+       return null;
+    }
+    return response.data.data; 
+  } catch (error) {
+    console.error('Failed to fetch last read page:', error.message);
+    return null; 
+  }
+};
+
+export const saveLastReadPage = async (storyId, childId, pageNumber) => {
+  const API_ENDPOINT = `/api/stories/${storyId}/children/${childId}/pages/${pageNumber}`;
+
+  try {
+    const response = await instance.patch(API_ENDPOINT);
+    return response.data;
+  } catch (error) {
+    console.error('Failed to save page:', error.message);
+    throw error;
+  }
+};

--- a/Frontend/src/hooks/useStory.js
+++ b/Frontend/src/hooks/useStory.js
@@ -5,31 +5,28 @@ import { fetchStoryById } from '../api/storyApi.js';
  * storyId를 기반으로 스토리 데이터와 페이지네이션 로직을 관리하는 훅
  * @param {string} storyId - useParams()로 받은 스토리 ID
  */
-export const useStory = (storyId) => {
-    const [page, setPage] = useState(0);
+export const useStory = (storyId, initialPage = 0) => {
+    const [page, setPage] = useState(initialPage);
     const [storyData, setStoryData] = useState(null);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState(null);
 
     useEffect(() => {
-        const fetchStory = async () => {
-            setIsLoading(true);
-            setError(null);
-            setStoryData(null);
-            setPage(0);
-            
-            try {
-                const data = await fetchStoryById(storyId);
+        const fetchStory = async () => {
+            setIsLoading(true);
+            setError(null);
+            setStoryData(null);            
+            try {
+                const data = await fetchStoryById(storyId);
                 setStoryData(data); 
-            
-            } catch (err) {
-                setError(err.message || '동화를 불러오는데 실패했습니다.');
-            } finally {
-                setIsLoading(false);
-            }
-        };
+            } catch (err) {
+                setError(err.message || '동화를 불러오는데 실패했습니다.');
+            } finally {
+                setIsLoading(false);
+            }
+        };
 
-        if (storyId) {
+        if (storyId) {
             fetchStory(); 
         } else {
             setIsLoading(false);


### PR DESCRIPTION
## 관련 이슈
> close #243 

<br>

## 작업 내용
> 
- API 연동: 마지막 읽은 페이지 조회 (`fetchLastReadPage`) 및 저장 (`saveLastReadPage`) 함수 추가
- `useStory.js`: `initialPage` 파라미터를 추가하여 특정 페이지에서 동화를 시작할 수 있도록 수정
- `StoryList.jsx`
  - 동화 클릭 시 API를 호출하여 저장된 기록 확인
  - 기록이 있고 완독하지 않은 경우 '이어보기' 팝업 노출
  - `total_pages` 정보를 정확히 가져오기 위해 상세 조회 API 병렬 호출
- `StoryPage.jsx`
  - 홈 버튼 클릭 또는 브라우저 종료 시 현재 페이지 정보 저장
  - 예외 처리: 표지(0페이지)는 저장하지 않음 (백엔드 404 방지)
  - 마지막 페이지 도달 시 저장하되, 목록 진입 시 완독으로 판단하여 팝업 띄우지 않음

<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
