### PR TITLE
[BE] Feat : 동화 완독 여부 처리 추가

### DIFF
--- a/Backend/src/main/java/com/example/namurokmurok/domain/story/controller/StoryController.java
+++ b/Backend/src/main/java/com/example/namurokmurok/domain/story/controller/StoryController.java
@@ -79,7 +79,7 @@ public class StoryController {
         return ApiResponse.success(response);
     }
 
-    @PatchMapping("{story-id}/children/{child-id}/pages/{page-number}")
+    @PatchMapping("{story-id}/children/{child-id}/pages")
     @Operation(summary = "아이별 동화 페이지 저장/수정",
             description = "아이별 동화 페이지를 저장/수정합니다.")
     public ApiResponse<Void> savePage(
@@ -89,10 +89,9 @@ public class StoryController {
             @Parameter(description = "아이 ID", example = "3")
             @PathVariable("child-id") Long childId,
 
-            @Parameter(description = "페이지", example = "1")
-            @PathVariable("page-number") int pageNumber) {
+            @RequestBody ChildStoryPageUpdateRequestDto request) {
 
-        storyService.saveOrUpdatePage(storyId, childId, pageNumber);
+        storyService.saveOrUpdatePage(storyId, childId, request);
         return ApiResponse.success("아이의 동화 페이지가 저장 되었습니다.", null);
     }
 

--- a/Backend/src/main/java/com/example/namurokmurok/domain/story/dto/ChildStoryPageResponseDto.java
+++ b/Backend/src/main/java/com/example/namurokmurok/domain/story/dto/ChildStoryPageResponseDto.java
@@ -21,4 +21,8 @@ public class ChildStoryPageResponseDto {
     @Schema(description = "페이지", example = "7")
     @JsonProperty("page_number")
     private int pageNumber;
+
+    @Schema(description = "완독 여부", example = "false")
+    @JsonProperty("is_end")
+    private Boolean end;
 }

--- a/Backend/src/main/java/com/example/namurokmurok/domain/story/dto/ChildStoryPageUpdateRequestDto.java
+++ b/Backend/src/main/java/com/example/namurokmurok/domain/story/dto/ChildStoryPageUpdateRequestDto.java
@@ -1,0 +1,21 @@
+package com.example.namurokmurok.domain.story.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ChildStoryPageUpdateRequestDto {
+
+    @Schema(description = "페이지 ", example = "10", nullable = true)
+    @JsonProperty("page_number")
+    private Integer pageNumber;
+
+    @Schema(description = "완독 여부", example = "true", nullable = true)
+    @JsonProperty("is_end")
+    private Boolean end;
+}

--- a/Backend/src/main/java/com/example/namurokmurok/domain/story/entity/ChildStoryPage.java
+++ b/Backend/src/main/java/com/example/namurokmurok/domain/story/entity/ChildStoryPage.java
@@ -21,6 +21,10 @@ public class ChildStoryPage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "is_end", nullable = false)
+    @Builder.Default
+    private boolean isEnd = false;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "child_id", nullable = false)
     private Child child;
@@ -40,4 +44,13 @@ public class ChildStoryPage {
         this.storyPage = newPage;
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void setIsEnd(boolean isEnd) {
+        this.isEnd = isEnd;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
 }

--- a/Backend/src/main/java/com/example/namurokmurok/domain/story/repository/StoryPageRepository.java
+++ b/Backend/src/main/java/com/example/namurokmurok/domain/story/repository/StoryPageRepository.java
@@ -2,6 +2,7 @@ package com.example.namurokmurok.domain.story.repository;
 
 import com.example.namurokmurok.domain.story.entity.StoryPage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -10,4 +11,7 @@ public interface StoryPageRepository extends JpaRepository<StoryPage, Long> {
 
     Optional<StoryPage> findByStoryIdAndPageNumber(Long storyId, Integer pageNumber);
 
+    // 동화의 마지막 페이지 조회
+    @Query("SELECT MAX(sp.pageNumber) FROM StoryPage sp WHERE sp.story.id = :storyId")
+    Optional<Integer> findLastPageNumberByStoryId(Long storyId);
 }

--- a/Backend/src/main/java/com/example/namurokmurok/global/common/exception/ErrorCode.java
+++ b/Backend/src/main/java/com/example/namurokmurok/global/common/exception/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
     CHILD_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 아이입니다"),
     CHILD_NOT_FOUND_FOR_USER(HttpStatus.NOT_FOUND, "등록된 아이가 없습니다."),
     CHILD_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 아이에게 접근 권한이 없습니다."),
-    CHILD_STORY_PROGRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 아이에게 저장된 동화 페이지가 존재하지 않습니다.."),
+    CHILD_STORY_PROGRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "아이에게 저장된 해당 동화의 페이지가 존재하지 않습니다."),
 
     // story 관련
     INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "잘못된 카테고리입니다."),
@@ -34,6 +34,8 @@ public enum ErrorCode {
     DIALOGUE_PAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "대화 장면이 존재하지 않습니다."),
     INTRO_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "인트로 질문이 존재하지 않습니다"),
     ACTION_CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "행동 카드가 존재하지 않습니다"),
+    INVALID_END_REQUEST(HttpStatus.BAD_REQUEST, "완독 요청이 유효하지 않습니다. 마지막 페이지에서만 완료 처리가 가능합니다."),
+    PAGE_NUMBER_REQUIRED_FOR_END(HttpStatus.BAD_REQUEST, "완독 요청 시 page_number는 필수입니다."),
 
     // conversation 관련
     CONVERSATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 대화입니다"),


### PR DESCRIPTION
## 관련 이슈
#245 
<br>

## 작업 내용
- ChildStoryPage 엔티티에 isEnd (완독 여부) 필드 추가
- 아이별 동화 페이지 저장/수정, 조회 API에 isEnd 응답 값 추가
- 아이별 동화 페이지 저장/수정 API 요청 dto 활용으로 리팩토링
<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
