### PR TITLE
[FE] Feat : 동화 완독 API 400 에러 수정 및 이어보기 로직 개선

### DIFF
--- a/Frontend/src/api/storyApi.js
+++ b/Frontend/src/api/storyApi.js
@@ -68,11 +68,16 @@ export const fetchLastReadPage = async (storyId, childId) => {
   }
 };
 
-export const saveLastReadPage = async (storyId, childId, pageNumber) => {
-  const API_ENDPOINT = `/api/stories/${storyId}/children/${childId}/pages/${pageNumber}`;
+export const saveLastReadPage = async (storyId, childId, pageNumber, isEnd = false) => {
+  const API_ENDPOINT = `/api/stories/${storyId}/children/${childId}/pages`;
+
+  const body = {
+    page_number: pageNumber,
+    is_end: isEnd
+  };
 
   try {
-    const response = await instance.patch(API_ENDPOINT);
+    const response = await instance.patch(API_ENDPOINT, body);
     return response.data;
   } catch (error) {
     console.error('Failed to save page:', error.message);

--- a/Frontend/src/pages/StoryList.jsx
+++ b/Frontend/src/pages/StoryList.jsx
@@ -128,7 +128,7 @@ const StoryList = () => {
             전체페이지: totalStoryPages 
         });
 
-        if (savedPage !== null && savedPage !== undefined && savedPage > 0 && savedPage < (totalStoryPages - 1)) {
+        if (savedPage !== null && savedPage !== undefined && savedPage > 0 && savedPage < totalStoryPages) {
             console.log(`[DEBUG_LIST] ✅ 이어보기 팝업 조건 충족!`);
             setResumeInfo({ storyId, savedPage });
             setResumeModalOpen(true);

--- a/Frontend/src/pages/StoryPage.jsx
+++ b/Frontend/src/pages/StoryPage.jsx
@@ -51,7 +51,7 @@ const StoryPage = () => {
      fetchChildId();
   }, []);
 
-  const saveProgress = async () => {
+  const saveProgress = async (isEnd = false) => {
     if (!childId || !storyId) return;
 
     if (page === 0) {
@@ -59,8 +59,8 @@ const StoryPage = () => {
     }
 
     try {
-        console.log(`[DEBUG_PAGE] 현재 진행상황 저장: ${page}페이지`);
-        await saveLastReadPage(storyId, childId, page);
+        console.log(`[DEBUG_PAGE] 저장 시도 - 페이지: ${page}, 완독여부: ${isEnd}`);
+        await saveLastReadPage(storyId, childId, page, isEnd); 
         
     } catch (e) {
         console.error("[DEBUG_PAGE] 🚨 저장 API 실패:", e);
@@ -69,7 +69,7 @@ const StoryPage = () => {
 
   useEffect(() => {
     const handleBeforeUnload = (e) => {
-        saveProgress();
+        saveProgress(false);
     };
 
     window.addEventListener('beforeunload', handleBeforeUnload);
@@ -134,7 +134,7 @@ const StoryPage = () => {
   };
 
   const handleExitConfirm = async () => {
-    await saveProgress();
+    await saveProgress(false);
     setIsExitModalOpen(false);
     navigate('/stories'); 
   };
@@ -155,10 +155,14 @@ const StoryPage = () => {
   }
 
   const goToChatIntro = async () => {
-    if (childId && storyId) {
+    if (childId && storyId && storyData) {
         try {
-            console.log(`[DEBUG_PAGE] 대화하러 가기 클릭! 현재 페이지(${page}) 저장.`);
-            await saveLastReadPage(storyId, childId, page); 
+            const finalPageNumber = storyData.total_pages;
+
+            console.log(`[DEBUG_PAGE] 대화하러 가기 클릭!`);
+            console.log(`- 전송할 페이지 번호(total_pages): ${finalPageNumber}`);
+            
+            await saveLastReadPage(storyId, childId, finalPageNumber, true); 
             
         } catch (e) {
             console.error("[DEBUG_PAGE] 마지막 페이지 저장 실패:", e);


### PR DESCRIPTION
## 관련 이슈
> close #248 

<br>

## 작업 내용
> 
- `storyApi.js`: `saveLastReadPage` 호출 시 URL 파라미터 대신 Request Body에 `page_number`와 `is_end`를 담아 보내도록 수정
- `StoryPage.jsx`: '대화하러 가기' 버튼 클릭 시에만 `is_end: true`를 전송하도록 구현
- `StoryList.jsx`: 마지막 페이지에서 완독 처리 하지 않고 이탈한 경우에도 이어보기 팝업 뜨도록 수정

<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
