### PR TITLE
[FE] Feat : 동화 오디오 제어 및 페이지 이탈 시 저장 로직 개선

### DIFF
--- a/Frontend/src/api/storyApi.js
+++ b/Frontend/src/api/storyApi.js
@@ -84,3 +84,38 @@ export const saveLastReadPage = async (storyId, childId, pageNumber, isEnd = fal
     throw error;
   }
 };
+
+export const saveLastReadPageOnExit = (storyId, childId, pageNumber, isEnd = false) => {
+  const BASE_URL = 'http://43.203.13.222:8080'; 
+  const URL = `${BASE_URL}/api/stories/${storyId}/children/${childId}/pages`;
+
+  let token = null;
+  const storageKey = Object.keys(localStorage).find(key => key.startsWith('sb-') && key.endsWith('-auth-token'));
+  const sessionString = storageKey ? localStorage.getItem(storageKey) : null;
+
+  if (sessionString) {
+    try {
+      const session = JSON.parse(sessionString);
+      token = session.access_token; 
+    } catch (e) {
+      console.error("[Exit Save] 토큰 파싱 실패:", e);
+    }
+  }
+
+  console.log(`[EXIT DEBUG] 토큰 찾음: ${!!token} (Key: ${storageKey})`);
+  
+  const body = JSON.stringify({
+    page_number: pageNumber,
+    is_end: isEnd
+  });
+
+  fetch(URL, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token && { 'Authorization': `Bearer ${token}` }),
+    },
+    body: body,
+    keepalive: true 
+  }).catch(e => console.error("Exit save failed:", e));
+};

--- a/Frontend/src/hooks/useAudioPlayback.js
+++ b/Frontend/src/hooks/useAudioPlayback.js
@@ -24,12 +24,34 @@ export const useAudioPlayback = (audioSrc, shouldPlay) => {
                 });
             }
         } else {
-            // 재생 조건이 아니면 정지
             audio.pause();
             audio.currentTime = 0;
         }
 
     }, [audioSrc, shouldPlay]); 
+
+    useEffect(() => {
+    const handleVisibilityChange = () => {
+      const audio = audioRef.current;
+      if (!audio) return;
+
+      if (document.visibilityState === 'hidden') {
+        console.log("[Audio] 앱 백그라운드 전환 -> 오디오 일시정지");
+        audio.pause(); 
+      } 
+      else if (document.visibilityState === 'visible') {
+        if (shouldPlay && audioSrc) {
+            console.log("[Audio] 앱 포그라운드 전환 -> 오디오 재개 시도");
+            audio.play().catch(e => console.log("자동 재생 정책으로 인해 재생 실패:", e));
+        }
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [shouldPlay, audioSrc]);
 
     // 컴포넌트 언마운트 시 오디오 정리
     useEffect(() => {


### PR DESCRIPTION
## 관련 이슈
> close #250

<br>

## 작업 내용
> 
- `useAudioPlayback.js`: visibilitychange` 이벤트를 추가하여 브라우저 탭을 숨기거나 모바일 앱을 내렸을 때 오디오가 일시정지되도록 수정
- `storyApi.js`, `StoryPage.jsx`
  - `saveLastReadPageOnExit` 함수 추가: `axios` 대신 `fetch` API와 `keepalive: true` 옵션을 사용하여 모바일에서 브라우저가 닫히는 순간에도 요청이 취소되지 않도록 구현
  - 뒤로 가기(Cleanup) 및 모바일 종료(Visibility Hidden) 시점에 저장 함수가 실행되도록 `useEffect` 로직을 통합
<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
